### PR TITLE
renovate: rollback previous version of postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       timeout: 3s
       retries: 50
   pgsql:
-    image: postgres:18-alpine
+    image: postgres:17-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
### Context

For Postgres V18, a dump/restore using _pg_dumpall_ or use of _pg_upgrade_ or logical replication is required for those wishing to migrate data from any previous release. [Release notes](https://www.postgresql.org/docs/release/18.0/)

### Issue linked

On openaev repository [#123](https://github.com/OpenAEV-Platform/docker/issues/123)

After some investigation, it appears that this resulted in breaking changes and without providing a clear migration path for our users.
We will work on resolving this and, in the meantime, revert to V17.

Here is a detailed [documentation ](https://aronschueler.de/blog/2025/10/30/fixing-postgres-18-docker-compose-startup/
) explaining the ins and outs. 