### PR TITLE
[docker] Align infra image versions with standalone repos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
 
   # Generate RSA key for xtm-composer (PKCS#8 format)
   rsa-key-generator:
-    image: alpine/openssl:3.5.5
+    image: alpine/openssl:latest
     volumes:
       - rsakeys:/keys
     entrypoint: ["/bin/ash"]
@@ -18,7 +18,7 @@ services:
       retries: 3
     restart: always
   redis:
-    image: redis:8.6.1
+    image: redis:8.6.3
     restart: always
     ports:
       - "6379:6379"
@@ -30,7 +30,7 @@ services:
       timeout: 5s
       retries: 3
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.12
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.16
     volumes:
       - esdata:/usr/share/elasticsearch/data
     environment:
@@ -88,7 +88,7 @@ services:
       timeout: 5s
       retries: 5
   minio:
-    image: minio/minio:RELEASE.2025-06-13T11-33-47Z
+    image: minio/minio:latest
     volumes:
       - s3data:/data
     ports:
@@ -104,7 +104,7 @@ services:
       timeout: 5s
       retries: 3
   rabbitmq:
-    image: rabbitmq:4.2-management
+    image: rabbitmq:4.3-management
     environment:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}


### PR DESCRIPTION
## Summary

Aligns the shared infrastructure image versions in the unified XTM stack with the per-platform standalone docker repos (`OpenCTI-Platform/docker`, `OpenAEV-Platform/docker`), which had drifted ahead. Brings the combined stack up to the same tested versions.

| Image | Before | After |
|-------|--------|-------|
| alpine/openssl | `3.5.5` | `latest` |
| redis | `8.6.1` | `8.6.3` |
| elasticsearch | `8.19.12` | `8.19.16` |
| minio | pinned `RELEASE.2025-06-13` | `latest` |
| rabbitmq | `4.2-management` | `4.3-management` |

XTM One service definitions (`xtm-one`, `xtm-one-worker`, `pgsql-xtm-one`) were already consistent and are unchanged.

## Test plan
- [x] `docker compose --env-file .env.sample -f docker-compose.yml config` validates with no errors
- [ ] Full stack (OpenCTI + OpenAEV + XTM One) boots and all services reach healthy state