### PR TITLE
chore(dependabot): emit Conventional Commits titles (#27)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

Future Dependabot security-update PRs will be Conventional-Commits named (`chore(deps): ...`); version updates stay with Renovate (`open-pull-requests-limit: 0`).

Detected ecosystems: github-actions

Closes #27