### PR TITLE
fix(openaev): align healthcheck on application-level /api/health endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -446,10 +446,10 @@ services:
         condition: service_healthy
     restart: always
     healthcheck:
-      test: [ "CMD", "wget", "-qO-", "http://openaev:8080/actuator/health/ping" ]
+      test: [ "CMD", "wget", "-qO-", "http://openaev:8080/api/health?health_access_key=${OPENAEV_HEALTHCHECK_KEY}" ]
       interval: 10s
       timeout: 5s
-      retries: 30
+      retries: 20
       start_period: 120s
 
   ###########################


### PR DESCRIPTION
## What

Aligns the `openaev` service healthcheck in `docker-compose.yml` with the pattern already used for `opencti` in the same file, and with `OpenAEV-Platform/docker`'s own compose file.

```diff
     healthcheck:
-      test: [ "CMD", "wget", "-qO-", "http://openaev:8080/actuator/health/ping" ]
+      test: [ "CMD", "wget", "-qO-", "http://openaev:8080/api/health?health_access_key=${OPENAEV_HEALTHCHECK_KEY}" ]
       interval: 10s
       timeout: 5s
-      retries: 30
-      start_period: 120s
+      retries: 20
+      start_period: 120s
```

## Why

- `/actuator/health/ping` is a generic Spring Boot Actuator **liveness** probe — it only proves the JVM process responds, with no visibility into whether OpenAEV's actual dependencies (Postgres, MinIO, RabbitMQ, Elasticsearch) are reachable.
- `/api/health?health_access_key=` is OpenAEV's **application-level** health endpoint — a real readiness check, same mechanism OpenCTI already uses in this same file (`/health?health_access_key=${OPENCTI_HEALTHCHECK_ACCESS_KEY}`) and the one used in `OpenAEV-Platform/docker`.
- Several services depend on `openaev: condition: service_healthy` (`xtm-composer`, all `collector-*` and `injector-*` services). A liveness-only check means those consumers can start against an OpenAEV instance that's "up" but not actually ready to serve traffic (e.g. DB migration still running).
- `OPENAEV_HEALTHCHECK_KEY` is already defined and injected in the `openaev` service environment (`OPENAEV_HEALTHCHECK_KEY=${OPENAEV_HEALTHCHECK_KEY:-ChangeMe}`), so **no new secret/env var is introduced**.

## Notes

- `retries` lowered from 30 → 20 to match `OpenAEV-Platform/docker`.
- `start_period: 120s` kept: this is now a real app-level readiness check (DB/ES/MinIO init), which can reasonably take longer to go green than a bare actuator ping — happy to drop it if we'd rather match `OpenAEV-Platform/docker` exactly (no `start_period` there).

## Scope / impact

- Infra-only change (`docker-compose.yml`), no application code touched.
- No CE/EE impact, no public API breaking change, no multi-tenancy impact.
- Slightly stricter startup gating for `xtm-composer` / collectors / injectors that wait on `openaev: service_healthy` — expected and desired.

Related discussion: Teams thread on healthcheck inconsistency between `docker` and `xtm-docker` repos.
